### PR TITLE
Patch a release

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -49,7 +49,7 @@ class AppleAppV1 < Hanami::API
 
     scope "release" do
       post "prepare" do
-        json(DOMAIN.create_app_store_version(**env[:app_store_connect_params].merge(params)))
+        json(DOMAIN.prepare_release(**env[:app_store_connect_params].merge(params)))
       end
 
       patch "submit" do

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -128,7 +128,7 @@ module AppStore
     end
 
     # no of api calls: 5-11
-    def create_app_store_version(build_number:, version:, is_phased_release:, is_force: false, metadata:)
+    def create_app_store_version(build_number:, version:, is_phased_release:, metadata:, is_force: false)
       execute do
         build = get_build(build_number)
         update_export_compliance(build)

--- a/test/requests
+++ b/test/requests
@@ -72,8 +72,7 @@ POST http://127.0.0.1::port/apple/connect/v1/apps/com.tramline.ueno/release/prep
 PATCH http://127.0.0.1::port/apple/connect/v1/apps/com.tramline.ueno/release/submit
 :my-headers
 {
-"build_number": :build-number,
-"version": :version
+"build_number": :build-number
 }
 #
 


### PR DESCRIPTION
- Prepare release fails with `VersionAlreadyAddedToSubmissionError` unless a new release can be created
- Allow prepare release API to overwrite the previous release if `is_force` is passed -- handle the previous release being in all possible states
- Reduce the number of API calls to appstore connect across the board by making some API calls directly instead of using Spaceship's model interface

NOTE: does not break API signature, but does change the behavior of prepare release which gets handled by Tramline in https://github.com/tramlinehq/tramline/pull/401