### PR TITLE
Add retry to updating app store version details

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -372,7 +372,7 @@ module AppStore
 
     # no of api calls: 1
     def update_version_details!(app_store_version, version, build)
-      attempt ||= 1
+      attempts ||= 1
       execute do
         body = {
           data: {
@@ -381,14 +381,14 @@ module AppStore
           }.merge(build_app_store_version_attributes(version, build, app_store_version))
         }
 
-        log "Updating app store version details with ", {body: body, attempt: attempts}
+        log "Updating app store version details with ", {body: body, attempts: attempts}
         api.tunes_request_client.patch("appStoreVersions/#{app_store_version.id}", body)
 
         app_store_version
       end
     rescue VersionNotEditableError => e
-      if attempt <= 3
-        attempt += 1
+      if attempts <= 3
+        attempts += 1
         retry
       else
         Sentry.capture_exception(e)

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -372,17 +372,28 @@ module AppStore
 
     # no of api calls: 1
     def update_version_details!(app_store_version, version, build)
-      body = {
-        data: {
-          type: "appStoreVersions",
-          id: app_store_version.id
-        }.merge(build_app_store_version_attributes(version, build, app_store_version))
-      }
+      attempt ||= 1
+      execute do
+        body = {
+          data: {
+            type: "appStoreVersions",
+            id: app_store_version.id
+          }.merge(build_app_store_version_attributes(version, build, app_store_version))
+        }
 
-      log "Updating app store version details with ", body
-      api.tunes_request_client.patch("appStoreVersions/#{app_store_version.id}", body)
+        log "Updating app store version details with ", {body: body, attempt: attempts}
+        api.tunes_request_client.patch("appStoreVersions/#{app_store_version.id}", body)
 
-      app_store_version
+        app_store_version
+      end
+    rescue VersionNotEditableError => e
+      if attempt <= 3
+        attempt += 1
+        retry
+      else
+        Sentry.capture_exception(e)
+        raise e
+      end
     end
 
     def build_app_store_version_attributes(version, build, app_store_version = nil)

--- a/lib/app_store/errors.rb
+++ b/lib/app_store/errors.rb
@@ -165,7 +165,17 @@ module AppStore
     end
   end
 
-  class VersionNotEditableError < StandardError; end
+  class VersionNotEditableError < StandardError
+    MSG = "The release is not editable in its current state"
+
+    def initialize(msg = MSG)
+      super
+    end
+
+    def as_json
+      AppStore.error_as_json(:release, :release_not_editable, MSG)
+    end
+  end
 
   NOT_FOUND_ERRORS = [
     AppStore::AppNotFoundError,

--- a/lib/app_store/errors.rb
+++ b/lib/app_store/errors.rb
@@ -165,6 +165,8 @@ module AppStore
     end
   end
 
+  class VersionNotEditableError < StandardError; end
+
   NOT_FOUND_ERRORS = [
     AppStore::AppNotFoundError,
     AppStore::BuildNotFoundError,
@@ -180,7 +182,8 @@ module AppStore
     AppStore::BuildMismatchError,
     AppStore::VersionAlreadyAddedToSubmissionError,
     AppStore::VersionAlreadyExistsError,
-    AppStore::UnexpectedAppstoreError
+    AppStore::UnexpectedAppstoreError,
+    AppStore::VersionNotEditableError
   ]
 
   CONFLICT_ERRORS = [AppStore::PhasedReleaseAlreadyInStateError, AppStore::ReleaseNotEditableError, AppStore::ReleaseAlreadyHaltedError]

--- a/spaceship/wrapper_error.rb
+++ b/spaceship/wrapper_error.rb
@@ -20,6 +20,14 @@ module Spaceship
       {
         message_matcher: /The version number has been previously used. - \/data\/attributes\/versionString/,
         decorated_exception: AppStore::VersionAlreadyExistsError
+      },
+      {
+        message_matcher: /An attribute value is not acceptable for the current resource state. - The attribute 'versionString' can not be modified. - \/data\/attributes\/versionString/,
+        decorated_exception: AppStore::VersionNotEditableError
+      },
+      {
+        message_matcher: /A relationship value is not acceptable for the current resource state. - The specified pre-release build could not be added. - \/data\/relationships\/build/,
+        decorated_exception: AppStore::VersionNotEditableError
       }
     ]
 


### PR DESCRIPTION
Sometimes update fails after a submission cancellation because state is not yet being persisted on the Apple side.