### PR TITLE
Fix creation of app store version in prepare release API

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -362,10 +362,12 @@ module AppStore
     # no of api calls: 2
     def create_app_store_version(version, build)
       log "Creating a new app store version"
-      body = build_app_store_version_attributes(version, build)
-      body[:relationships][:app] = {data: {type: "apps", id: app.id}}
-      body[:attributes][:platform] = IOS_PLATFORM
+      data = build_app_store_version_attributes(version, build)
+      data[:relationships][:app] = {data: {type: "apps", id: app.id}}
+      data[:attributes][:platform] = IOS_PLATFORM
+      body = {data: data}
 
+      log "Creating app store version with ", {body: body}
       api.tunes_request_client.post("appStoreVersions", body)
       app.get_edit_app_store_version(includes: VERSION_DATA_INCLUDES)
     end
@@ -376,7 +378,6 @@ module AppStore
       execute do
         body = {
           data: {
-            type: "appStoreVersions",
             id: app_store_version.id
           }.merge(build_app_store_version_attributes(version, build, app_store_version))
         }
@@ -418,6 +419,7 @@ module AppStore
       end
 
       body = {
+        type: "appStoreVersions",
         attributes: attributes,
         relationships: (relationships unless relationships.nil?)
       }

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -361,7 +361,6 @@ module AppStore
 
     # no of api calls: 2
     def create_app_store_version(version, build)
-      log "Creating a new app store version"
       data = build_app_store_version_attributes(version, build)
       data[:relationships][:app] = {data: {type: "apps", id: app.id}}
       data[:attributes][:platform] = IOS_PLATFORM


### PR DESCRIPTION
This fixes the prepare release API flow when no app store version exists -- a release was just done and no new release versions were prepared after that.

Fixes: https://tramline.sentry.io/issues/4080357673/?project=4504591889268736