### PR TITLE
Safe navigate when getting build relationship data

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -478,12 +478,12 @@ module AppStore
       {
         id: build.id,
         build_number: build.version,
-        beta_internal_state: build.build_beta_detail.internal_build_state,
-        beta_external_state: build.build_beta_detail.external_build_state,
+        beta_internal_state: build.build_beta_detail&.internal_build_state,
+        beta_external_state: build.build_beta_detail&.external_build_state,
         uploaded_date: build.uploaded_date,
         expired: build.expired,
         processing_state: build.processing_state,
-        version_string: build.pre_release_version.version
+        version_string: build.pre_release_version&.version
       }
     end
 


### PR DESCRIPTION
This is to ensure that the API does not blow up when the build does not have `build_beta_detail` or `pre_release_version`.