### PR TITLE
Retry getting build until build is processed and has beta details

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -527,7 +527,7 @@ module AppStore
     end
 
     def build_ready?(build)
-      build&.processed? || build&.build_beta_detail
+      build&.processed? && build&.build_beta_detail
     end
 
     def execute


### PR DESCRIPTION
### Why

App Store Connect APIs seems to be flaky where the build beta details are sometimes not returned even when `included` with the get build API