### PR TITLE
Handle build already in review when submitting a build for bete review

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -338,6 +338,7 @@ module AppStore
 
     private
 
+    # no of api calls: 1-4 ; +3 with every retry attempt
     def submit_for_beta_review(build)
       attempts ||= 1
       execute do
@@ -350,8 +351,7 @@ module AppStore
         waiting_for_review_build = app.get_builds(
           filter: {"betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW,IN_REVIEW",
                    "expired" => false,
-                   "preReleaseVersion.version" => build.pre_release_version.version},
-          includes: "betaAppReviewSubmission,preReleaseVersion"
+                   "preReleaseVersion.version" => build.pre_release_version.version}
         ).first
         if waiting_for_review_build
           waiting_for_review_build.expire!
@@ -577,8 +577,7 @@ module AppStore
     def execute
       yield
     rescue Spaceship::UnexpectedResponse => e
-      wrapped_error = Spaceship::WrapperError.handle(e)
-      raise wrapped_error
+      raise Spaceship::WrapperError.handle(e)
     end
 
     def to_bool(s)

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -126,7 +126,7 @@ module AppStore
         group = group(group_id)
         build = update_export_compliance(build)
 
-        build.post_beta_app_review_submission if build.ready_for_beta_submission? && !group.is_internal_group
+        submit_for_beta_review(build) unless group.is_internal_group
         build.add_beta_groups(beta_groups: [group])
       end
     end
@@ -337,6 +337,34 @@ module AppStore
     end
 
     private
+
+    def submit_for_beta_review(build)
+      attempts ||= 1
+      execute do
+        log("Submitting build #{build.version} for beta review. Attempt - #{attempts}")
+        build.post_beta_app_review_submission if build.ready_for_beta_submission?
+      end
+    rescue AppStore::ReviewAlreadyInProgressError => e
+      log("There is a build already in review, expiring that. Attempt - #{attempts}")
+      if attempts <= 3
+        waiting_for_review_build = app.get_builds(
+          filter: {"betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW,IN_REVIEW",
+                   "expired" => false,
+                   "preReleaseVersion.version" => build.pre_release_version.version},
+          includes: "betaAppReviewSubmission,preReleaseVersion"
+        ).first
+        if waiting_for_review_build
+          waiting_for_review_build.expire!
+          log("Expired build - #{waiting_for_review_build.version}.")
+        end
+        attempts += 1
+        sleep attempts
+        log("Retrying submitting build #{build.version} for beta review.")
+        retry
+      else
+        raise e
+      end
+    end
 
     def get_latest_app_store_version
       filter = {
@@ -549,7 +577,8 @@ module AppStore
     def execute
       yield
     rescue Spaceship::UnexpectedResponse => e
-      raise Spaceship::WrapperError.handle(e)
+      wrapped_error = Spaceship::WrapperError.handle(e)
+      raise wrapped_error
     end
 
     def to_bool(s)

--- a/spaceship/wrapper_error.rb
+++ b/spaceship/wrapper_error.rb
@@ -28,6 +28,10 @@ module Spaceship
       {
         message_matcher: /A relationship value is not acceptable for the current resource state. - The specified pre-release build could not be added. - \/data\/relationships\/build/,
         decorated_exception: AppStore::VersionNotEditableError
+      },
+      {
+        message_matcher: /Another build is in review/,
+        decorated_exception: AppStore::ReviewAlreadyInProgressError
       }
     ]
 


### PR DESCRIPTION
Closes #21 

Expire an older build waiting for review if a newer build comes for the same version name.

Removing the build from review would be a better option than expiring it, but App Store Connect API to remove the build from beta review doesn't exist.

More context: https://github.com/fastlane/fastlane/issues/18408#issuecomment-1640343154