### PR TITLE
Simplify groups API to remove internal filter and testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,61 +237,31 @@ One can also use [requests](test/requests) in [restclient-mode](https://github.c
 
 ##### Success response
 > ```json
-> [
->   {
->     "name": "The Pledge",
->     "id": "fcacfdf7-db62-44af-a0cb-0676e17c251b",
->     "internal": true,
->     "testers": [
->       {
->         "name": "Akshay Gupta",
->         "email": "kitallis@gmail.com"
->       },
->       {
->         "name": "Pratul Kalia",
->         "email": "pratulkalia@gmail.com"
->       },
->       {
->         "name": "Nivedita Priyadarshini",
->         "email": "nid.mishra7@gmail.com"
->       }
->     ]
->   },
->   {
->     "name": "The Prestige",
->     "id": "2cd6be09-d959-4ed3-a4e7-db8cabbe44d0",
->     "internal": true,
->     "testers": [
->       {
->         "name": "Pratul Kalia",
->         "email": "pratulkalia@gmail.com"
->       }
->     ]
->   },
->   {
->     "name": "The Trick",
->     "id": "dab66de0-7af2-48ae-97af-cc8dfdbde51d",
->     "internal": true,
->     "testers": [
->       {
->         "name": "Nivedita Priyadarshini",
->         "email": "nid.mishra7@gmail.com"
->       }
->     ]
->   },
->   {
->     "name": "Big External Group",
->     "id": "3bc1ca3e-1d4f-4478-8f38-2dcae4dcbb69",
->     "internal": false,
->     "testers": []
->   },
->   {
->     "name": "Small External Group",
->     "id": "dc64b810-1157-4228-825b-eb9e95cc8fba",
->     "internal": false,
->     "testers": []
->   }
-> ]
+> [{
+>		"name": "The Pledge",
+>		"id": "fcacfdf7-db62-44af-a0cb-0676e17c251b",
+>		"internal": true
+>	},
+>	{
+>		"name": "The Prestige",
+>		"id": "2cd6be09-d959-4ed3-a4e7-db8cabbe44d0",
+>		"internal": true
+>	},
+>	{
+>		"name": "The Trick",
+>		"id": "dab66de0-7af2-48ae-97af-cc8dfdbde51d",
+>		"internal": true
+>	},
+>	{
+>		"name": "Big External Group",
+>		"id": "3bc1ca3e-1d4f-4478-8f38-2dcae4dcbb69",
+>		"internal": false
+>	},
+>	{
+>		"name": "Small External Group",
+>		"id": "dc64b810-1157-4228-825b-eb9e95cc8fba",
+>		"internal": false
+>	}]
 > ```
 
 </details>

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -6,7 +6,7 @@ require_relative "../../spaceship/wrapper_error"
 
 module AppStore
   class Connect
-    def self.groups(**params) = new(**params).groups(**params.slice(:internal))
+    def self.groups(**params) = new(**params).groups
 
     def self.build(**params) = new(**params).build(**params.slice(:build_number))
 
@@ -93,17 +93,9 @@ module AppStore
     end
 
     # no of api calls: 2
-    def groups(internal:)
-      app.get_beta_groups(includes: "betaTesters", filter: {isInternalGroup: to_bool(internal)}).map do |group|
-        testers =
-          group.beta_testers.map do |tester|
-            {
-              name: "#{tester.first_name} #{tester.last_name}",
-              email: tester.email
-            }
-          end
-
-        {name: group.name, id: group.id, internal: group.is_internal_group, testers: testers}
+    def groups
+      app.get_beta_groups.map do |group|
+        {name: group.name, id: group.id, internal: group.is_internal_group}
       end
     end
 
@@ -613,17 +605,6 @@ module AppStore
       yield
     rescue Spaceship::UnexpectedResponse => e
       raise Spaceship::WrapperError.handle(e)
-    end
-
-    def to_bool(s)
-      case s.downcase.strip
-      when "true", "yes", "on", "t", "1", "y", "=="
-        true
-      when "nil", "null"
-        nil
-      else
-        false
-      end
     end
 
     def log(msg, data = {})

--- a/test/requests
+++ b/test/requests
@@ -31,7 +31,7 @@ GET http://127.0.0.1::port/apple/connect/v1/apps/:bundle-id/current_status
 :my-headers
 #
 # Get beta groups for an app
-GET http://127.0.0.1::port/apple/connect/v1/apps/:bundle-id/groups/
+GET http://127.0.0.1::port/apple/connect/v1/apps/:bundle-id/groups
 :my-headers
 #
 


### PR DESCRIPTION
- Show all beta groups, internal and external
- Remove filter for group type
- Remove list of testers in the response