### PR TITLE
Change added_at for version data

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -534,7 +534,7 @@ module AppStore
         build_created_at: version.build&.uploaded_date,
         phased_release: version.app_store_version_phased_release,
         details: version.app_store_version_localizations&.first,
-        released_at: [version.created_date, version.build&.uploaded_date].compact.max
+        added_at: [version.created_date, version.build&.uploaded_date].compact.max
       }
     end
 

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -531,8 +531,10 @@ module AppStore
         created_date: version.created_date,
         build_number: version.build&.version,
         build_id: version.build&.id,
+        build_created_at: version.build&.uploaded_date,
         phased_release: version.app_store_version_phased_release,
-        details: version.app_store_version_localizations&.first
+        details: version.app_store_version_localizations&.first,
+        released_at: [version.created_date, version.build&.uploaded_date].compact.max
       }
     end
 

--- a/lib/internal.rb
+++ b/lib/internal.rb
@@ -12,7 +12,7 @@ module Internal
 
     payload = {
       iat: Time.now.to_i,
-      exp: Time.now.to_i + 1000,
+      exp: Time.now.to_i + 10000,
       aud: ENV["AUTH_AUD"],
       iss: ENV["AUTH_ISSUER"]
     }


### PR DESCRIPTION
Calculate by checking the higher of the build creation date or the version creation date.

![Screenshot 2023-08-03 at 2 51 59 PM](https://github.com/tramlinehq/applelink/assets/50663/ca6be6a1-635a-43f3-b4cc-98d72f83dd35)