### PR TITLE
Handle existing ReviewSubmissionItems gracefully

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -221,11 +221,7 @@ module AppStore
         end
 
         submission = app.get_ready_review_submission(platform: IOS_PLATFORM, includes: "items")
-
-        raise SubmissionWithItemsExistError if submission && !submission.items.empty?
-
         submission ||= app.create_review_submission(platform: IOS_PLATFORM)
-
         submission.add_app_store_version_to_review_items(app_store_version_id: edit_version.id)
 
         submit_review(submission, edit_version)


### PR DESCRIPTION
Also return any pending non-appStoreVersion submission items that are ready for review for the release endpoint, so it can be polled by Tramline and shown to the user.