### PR TITLE
Fix release lookup to find builds that auto-released after review

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -283,8 +283,8 @@ module AppStore
     def release(build_number: nil)
       execute do
         if build_number.nil? || build_number.empty?
-          version = find_any_release
-          raise VersionNotFoundError.new("No release found") unless version
+          version = current_inflight_release
+          raise VersionNotFoundError.new("No inflight release found") unless version
         else
           version = app.get_app_store_versions(includes: VERSION_DATA_INCLUDES, filter: ANY_RELEASE_FILTERS)
             .find { |v| v.build&.version == build_number }
@@ -394,11 +394,6 @@ module AppStore
 
     def current_inflight_release
       app.get_app_store_versions(includes: VERSION_DATA_INCLUDES, filter: INFLIGHT_RELEASE_FILTERS)
-        .max_by { |v| Date.parse(v.created_date) }
-    end
-
-    def find_any_release
-      app.get_app_store_versions(includes: VERSION_DATA_INCLUDES, filter: ANY_RELEASE_FILTERS)
         .max_by { |v| Date.parse(v.created_date) }
     end
 


### PR DESCRIPTION
## Summary
- When `release_type: AFTER_APPROVAL` is used, Apple transitions the version directly from `IN_REVIEW` to `READY_FOR_SALE`, bypassing `PENDING_DEVELOPER_RELEASE`. The `release()` method only searched `INFLIGHT_RELEASE_FILTERS` (which excludes `READY_FOR_SALE`), so Tramline could never find the version post-approval and stayed stuck showing "Submitted for Review."
- Extracts release states into composable frozen arrays (`INFLIGHT_RELEASE_STATES`, `LIVE_RELEASE_STATES`) and introduces `ANY_RELEASE_FILTERS` combining both.
- Updates `release()` to search across all release states (inflight + live), so it finds the version regardless of whether it landed in `PENDING_DEVELOPER_RELEASE` (manual) or `READY_FOR_SALE` (auto).
- Existing methods (`create_review_submission`, `cancel_review_submission`, `current_inflight_release`) continue using `INFLIGHT_RELEASE_FILTERS` unchanged.

## Test plan
- [x] Verify `release(build_number:)` finds a version in `PENDING_DEVELOPER_RELEASE` (manual release type, existing behavior)
- [x] Verify `release(build_number:)` finds a version in `READY_FOR_SALE` (auto release type, the fix)
- [x] Verify `release()` without build_number returns the most recent inflight release
- [x] Verify `create_review_submission` and `cancel_review_submission` still only search inflight versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)