### PR TITLE
feat: Allow updating additional metadata during release preparation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   x86_64-darwin-19
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ One can also use [requests](test/requests) in [restclient-mode](https://github.c
 > | is_phased_release | optional  | boolean   | flag to enable or disable phased release, defaults to false  |
 > | release_type | optional  | string   | release type, either "MANUAL" or "AFTER_APPROVAL", defaults to "MANUAL"  |
 > | is_force | optional  | boolean   | force prepare even if a release is already in progress, defaults to false  |
-> | metadata | required  | hash   | { "promotional_text": "this is the app store version promo text", "whats_new": "release notes"}  |
+> | metadata | required  | array  | list of localization hashes. Each item supports: `locale` (required), `whats_new` (optional; defaults to a generic message if blank), and optionally `promotional_text`, `description` and `keywords`  |
 
 ##### Example cURL
 
@@ -442,7 +442,7 @@ One can also use [requests](test/requests) in [restclient-mode](https://github.c
 > -H "X-AppStoreConnect-Issuer-Id: iss-id" \
 > -H "X-AppStoreConnect-Token: token" \
 > -H "Content-Type: application/json" \
-> -d '{"build_number": 9018, "version": "1.6.2", "is_phased_release": true, "metadata": {"promotional_text": "app store version promo text", "whats_new": "release notes"} }' \
+> -d '{"build_number": 9018, "version": "1.6.2", "is_phased_release": true, "metadata": [{"locale": "en-US", "promotional_text": "app store version promo text", "whats_new": "release notes", "description": "full description", "keywords": "tramline, releases"}] }' \
 > http://localhost:4000/apple/connect/v1/apps/com.tramline.app/release/prepare
 > ```
 

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -686,6 +686,14 @@ module AppStore
         locale_params["promotionalText"] = metadata[:promotional_text]
       end
 
+      unless metadata[:description].nil? || metadata[:description].empty?
+        locale_params["description"] = metadata[:description]
+      end
+
+      unless metadata[:keywords].nil? || metadata[:keywords].empty?
+        locale_params["keywords"] = metadata[:keywords]
+      end
+
       log "Updating locale for the app store version", {locale: locale.to_json, params: locale_params}
       locale.update(attributes: locale_params)
     end

--- a/test/requests
+++ b/test/requests
@@ -74,8 +74,11 @@ POST http://127.0.0.1::port/apple/connect/v1/apps/:bundle-id/release/prepare
 "build_number": :build-number,
 "version": "1.6.2",
 "is_phased_release": true,
-"metadata": { "promotional_text": "this is the app store version promo text",
-              "whats_new": "something new"}
+"metadata": [{ "promotional_text": "this is the app store version promo text",
+               "whats_new": "something new",
+               "locale": "en-US",
+               "description": "this is the app store version description",
+               "keywords": "keyword1, keyword2, keyword3" }]
 }
 #
 


### PR DESCRIPTION
**Closes:** https://github.com/orgs/tramlinehq/projects/5?pane=issue&itemId=94582410

**NOTE:** Getting this PR merged is a pre-condition for merging https://github.com/tramlinehq/tramline/pull/917.

## Why

We want to allow updating the `description` and `keywords` metadata for App Store releases.

## This addresses

Allowing & accepting `description` and `keywords` as optional request params within the `metadata` param for the `/apple/connect/v1/apps/:bundle_id/release/prepare` API endpoint.

 Turns out App Store Connect APIs already allowed updating the app's per-locale metadata.

App Store Connect API reference:
- https://developer.apple.com/documentation/appstoreconnectapi/patch-v1-appstoreversionlocalizations-_id_

Payload body reference:
- https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionlocalizationupdaterequest
- https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionlocalizationupdaterequest/data-data.dictionary
- https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionlocalizationupdaterequest/data-data.dictionary/attributes-data.dictionary

Fastlane already takes care of building the payload correctly, so we just needed to pass it along to `Spaceship::ConnectAPI::AppStoreVersionLocalization#update`.