### PR TITLE
fix: align Dockerfile for Kamal accessory on Hetzner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ COPY --from=build /applelink /applelink
 
 ENV LD_PRELOAD=libjemalloc.so.2
 
-EXPOSE 9292
+EXPOSE 4000
+
+CMD ["bundle", "exec", "rackup", "-s", "puma", "config.ru", "-p", "4000", "-o", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- Change exposed port from 9292 to 4000 to match `bin/prod` and Tramline's Kamal deploy config
- Add `CMD` so the container runs without needing an explicit command override from Kamal

Part of the Hetzner migration — applelink runs as a Kamal accessory in tramlinehq/tramline#930.

## Test plan
- [ ] `docker build -t applelink . && docker run -p 4000:4000 applelink` — verify it starts and responds on port 4000
- [ ] Verify `GET /ping` returns `pong`

🤖 Generated with [Claude Code](https://claude.com/claude-code)