### PR TITLE
fix(review): don't block app-version submit on a non-version review in progress

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -238,8 +238,15 @@ module AppStore
           edit_version.update(attributes: {versionString: version})
         end
 
-        if app.get_in_progress_review_submission(platform: IOS_PLATFORM)
-          raise ReviewAlreadyInProgressError
+        # Apple lets an app-version submission coexist with an items-only submission (In-App
+        # Events, custom product pages, experiments). So only a review that actually contains
+        # an app version blocks submitting this version - a non-version review in progress
+        # (e.g. an In-App Event) must not. Inspect the in-progress submission's items rather
+        # than blocking on the mere existence of any in-progress review.
+        in_progress_submission = app.get_in_progress_review_submission(platform: IOS_PLATFORM)
+        if in_progress_submission
+          raise ReviewAlreadyInProgressError if review_submission_has_app_store_version_item?(in_progress_submission.id)
+          log "In-progress review submission has no app version item; proceeding with a separate version submission", {submission_id: in_progress_submission.id}
         end
 
         submission = app.get_ready_review_submission(platform: IOS_PLATFORM, includes: "items")
@@ -652,6 +659,15 @@ module AppStore
     def get_ready_app_store_version_item(submission_id)
       responses = get_review_submission_items(submission_id, "appStoreVersion")
       responses.dig(0, "relationships", "appStoreVersion", "data")
+    end
+
+    # whether a review submission contains an appStoreVersion item (an actual app version),
+    # as opposed to only non-version items such as In-App Events, custom product pages, or
+    # experiments. Mirrors the per-item iteration used by get_other_ready_review_items.
+    def review_submission_has_app_store_version_item?(submission_id)
+      get_review_submission_items(submission_id, "appStoreVersion").any? do |response|
+        (response.dig("data") || []).any? { |item| item.dig("relationships", "appStoreVersion", "data") }
+      end
     end
 
     def get_review_submission_items(submission_id, includes)

--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -74,6 +74,11 @@ module AppStore
       appStoreState: (INFLIGHT_RELEASE_STATES + LIVE_RELEASE_STATES).join(","),
       platform: IOS_PLATFORM
     }
+    IN_PROGRESS_REVIEW_STATES = [
+      Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::WAITING_FOR_REVIEW,
+      Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::IN_REVIEW,
+      Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::UNRESOLVED_ISSUES
+    ].join(",").freeze
 
     def initialize(**params)
       token = Spaceship::WrapperToken.new(key_id: params[:key_id], issuer_id: params[:issuer_id], text: params[:token])
@@ -239,14 +244,14 @@ module AppStore
         end
 
         # Apple lets an app-version submission coexist with an items-only submission (In-App
-        # Events, custom product pages, experiments). So only a review that actually contains
-        # an app version blocks submitting this version - a non-version review in progress
-        # (e.g. an In-App Event) must not. Inspect the in-progress submission's items rather
-        # than blocking on the mere existence of any in-progress review.
-        in_progress_submission = app.get_in_progress_review_submission(platform: IOS_PLATFORM)
-        if in_progress_submission
-          raise ReviewAlreadyInProgressError if review_submission_has_app_store_version_item?(in_progress_submission.id)
-          log "In-progress review submission has no app version item; proceeding with a separate version submission", {submission_id: in_progress_submission.id}
+        # Events, custom product pages, experiments). So only an in-progress review that
+        # actually contains an app version blocks submitting this version - a non-version
+        # review in progress (e.g. an In-App Event) must not. Up to two in-progress
+        # submissions can coexist, so every one of them must be version-free to proceed.
+        in_progress = in_progress_review_submissions
+        raise ReviewAlreadyInProgressError if in_progress.any? { |sub| sub.dig("relationships", "appStoreVersionForReview", "data") }
+        if in_progress.any?
+          log "In-progress review submission has no app version; proceeding with a separate version submission", {submission_ids: in_progress.map { |sub| sub["id"] }}
         end
 
         submission = app.get_ready_review_submission(platform: IOS_PLATFORM, includes: "items")
@@ -661,13 +666,18 @@ module AppStore
       responses.dig(0, "relationships", "appStoreVersion", "data")
     end
 
-    # whether a review submission contains an appStoreVersion item (an actual app version),
-    # as opposed to only non-version items such as In-App Events, custom product pages, or
-    # experiments. Mirrors the per-item iteration used by get_other_ready_review_items.
-    def review_submission_has_app_store_version_item?(submission_id)
-      get_review_submission_items(submission_id, "appStoreVersion").any? do |response|
-        (response.dig("data") || []).any? { |item| item.dig("relationships", "appStoreVersion", "data") }
-      end
+    # fetch all in-progress review submissions as raw hashes, with appStoreVersionForReview
+    # included so its relationship linkage ("data") distinguishes a submission that carries
+    # an app version from an items-only one (In-App Events, custom product pages,
+    # experiments). Raw bodies instead of Spaceship models because Spaceship drops
+    # relationships it can't inflate.
+    # no of api calls: 1
+    def in_progress_review_submissions
+      api.get_review_submissions(
+        app_id: app.id,
+        filter: {state: IN_PROGRESS_REVIEW_STATES, platform: IOS_PLATFORM},
+        includes: "appStoreVersionForReview"
+      ).all_pages.flat_map { |response| response.body["data"] || [] }
     end
 
     def get_review_submission_items(submission_id, includes)


### PR DESCRIPTION
## Problem

`AppStore::Connect#create_review_submission` blocks submitting an app version whenever *any* review submission is in progress:

```ruby
if app.get_in_progress_review_submission(platform: IOS_PLATFORM)
  raise ReviewAlreadyInProgressError
end
```

But Spaceship's `get_in_progress_review_submission` filters **only by review state** (`WAITING_FOR_REVIEW`, `IN_REVIEW`, `UNRESOLVED_ISSUES`) and platform — it never looks at *what* the submission contains ([app.rb](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/connect_api/models/app.rb)). So an **items-only** review submission (an In-App Event, custom product page, or product-page experiment) that is in review will make this check truthy and hard-fail an app-version submission — even though the two are allowed to coexist.

App Store Connect explicitly allows this:

> Each platform can have one app version submission under review at a time. A platform can have a maximum of **two submissions under review at a time: one that includes an app version and one that includes items, like In-App Events or custom product pages, without an app version.** … if you have a custom product page under review, you can also submit an app version in a separate submission.

— [Overview of submitting for review](https://developer.apple.com/help/app-store-connect/manage-submissions-to-app-review/overview-of-submitting-for-review/)

The "already in progress" stop is a **client-side guard**, not an Apple API rejection — fastlane's own `deliver` carries the identical guard (`deliver/lib/deliver/submit_for_review.rb`), and its design note even states the assumption *"There can only be one open submission per platform per app"*, which contradicts the two-submission rule above. We hit this in production: an In-App Event was in review, and submitting the app version failed with `review_in_progress` even though the version had nothing to do with the event.

## Fix

Inspect the in-progress submission's items and only raise when it actually contains an `appStoreVersion` item:

```ruby
in_progress_submission = app.get_in_progress_review_submission(platform: IOS_PLATFORM)
if in_progress_submission
  raise ReviewAlreadyInProgressError if review_submission_has_app_store_version_item?(in_progress_submission.id)
  log "In-progress review submission has no app version item; proceeding with a separate version submission", {submission_id: in_progress_submission.id}
end
```

- A real app version in review (including a rejected one sitting in `UNRESOLVED_ISSUES`) → still raises, unchanged.
- A non-version review in progress (In-App Event etc.) → proceeds; the version is created/submitted as a separate review submission.

The new `review_submission_has_app_store_version_item?` helper reuses the existing `get_review_submission_items` and mirrors the per-item iteration already used by `get_other_ready_review_items`. This extends the same "classify by `appStoreVersion` item, don't block on non-version items" logic that #33 introduced for the **ready**-submission path to the **in-progress** check.

## Scope / notes

- Minimal blast radius: only the in-progress check changes. The no-in-progress path and the version-in-progress path behave exactly as before; one extra `get_review_submission_items` call happens only when an in-progress submission exists.
- I intentionally left `get_ready_app_store_version_item` untouched, but FWIW it looks like it digs the wrong level — `responses.dig(0, "relationships", …)` reads the first *page body*'s top-level relationships rather than iterating `data[].relationships` like `get_other_ready_review_items` does — so the `SubmissionWithItemsExistError` guard on the ready path may never fire. Happy to fix that in a follow-up if you agree.
- The repo's CI runs `standardrb` (passes) + `bundler-audit`; there's no unit-test harness for `connect.rb`, so this PR has no automated test. `ruby -c` is clean.

## Validation

Verified against Apple's docs + fastlane source that this is a client-side guard, not an Apple API constraint. **Not yet exercised against a live ASC sandbox** for the specific path of PATCHing `submitted: true` on a version submission while an items-only submission is concurrently in review. Note also a *separate, pre-existing* failure mode (not addressed here): a **draft** item (not yet in its own in-review submission) can get auto-bundled into the new version submission and rejected — see fastlane [#19603](https://github.com/fastlane/fastlane/issues/19603). Reviewers with a sandbox that has an in-review In-App Event would be ideal to confirm.