### PR TITLE
fix(review): don't block on items-only reviews linked to the live app version

### DIFF
--- a/lib/app_store/connect.rb
+++ b/lib/app_store/connect.rb
@@ -244,14 +244,16 @@ module AppStore
         end
 
         # Apple lets an app-version submission coexist with an items-only submission (In-App
-        # Events, custom product pages, experiments). So only an in-progress review that
-        # actually contains an app version blocks submitting this version - a non-version
-        # review in progress (e.g. an In-App Event) must not. Up to two in-progress
-        # submissions can coexist, so every one of them must be version-free to proceed.
-        in_progress = in_progress_review_submissions
-        raise ReviewAlreadyInProgressError if in_progress.any? { |sub| sub.dig("relationships", "appStoreVersionForReview", "data") }
+        # Events, custom product pages, experiments, standalone subscription/IAP reviews).
+        # So only an in-progress review that actually carries an app version under review
+        # blocks submitting this version. The appStoreVersionForReview linkage alone can't
+        # tell: ASC also links items-only submissions to the app's LIVE (READY_FOR_SALE)
+        # version, so the linked version's state decides. Up to two in-progress submissions
+        # can coexist, so every one of them must be version-free to proceed.
+        in_progress, linked_versions = in_progress_review_submissions
+        raise ReviewAlreadyInProgressError if in_progress.any? { |sub| version_review_in_progress?(sub, linked_versions) }
         if in_progress.any?
-          log "In-progress review submission has no app version; proceeding with a separate version submission", {submission_ids: in_progress.map { |sub| sub["id"] }}
+          log "In-progress review submissions carry no app version under review; proceeding with a separate version submission", {submission_ids: in_progress.map { |sub| sub["id"] }}
         end
 
         submission = app.get_ready_review_submission(platform: IOS_PLATFORM, includes: "items")
@@ -666,18 +668,36 @@ module AppStore
       responses.dig(0, "relationships", "appStoreVersion", "data")
     end
 
-    # fetch all in-progress review submissions as raw hashes, with appStoreVersionForReview
-    # included so its relationship linkage ("data") distinguishes a submission that carries
-    # an app version from an items-only one (In-App Events, custom product pages,
-    # experiments). Raw bodies instead of Spaceship models because Spaceship drops
-    # relationships it can't inflate.
+    # fetch all in-progress review submissions as raw hashes, plus the appStoreVersions
+    # resources their appStoreVersionForReview relationships point at (carried in the same
+    # response's `included` payload, so still one call). Raw bodies instead of Spaceship
+    # models because Spaceship drops relationships and includes it can't inflate.
     # no of api calls: 1
     def in_progress_review_submissions
-      api.get_review_submissions(
+      responses = api.get_review_submissions(
         app_id: app.id,
         filter: {state: IN_PROGRESS_REVIEW_STATES, platform: IOS_PLATFORM},
         includes: "appStoreVersionForReview"
-      ).all_pages.flat_map { |response| response.body["data"] || [] }
+      ).all_pages
+      submissions = responses.flat_map { |response| response.body["data"] || [] }
+      linked_versions = responses
+        .flat_map { |response| response.body["included"] || [] }
+        .select { |resource| resource["type"] == "appStoreVersions" }
+      [submissions, linked_versions]
+    end
+
+    # A review submission blocks a new app-version submission only if it actually carries
+    # an app version under review. The appStoreVersionForReview linkage alone is not
+    # enough: for items-only submissions (e.g. a standalone subscription review) ASC still
+    # links the app's live READY_FOR_SALE version. So a submission blocks only when its
+    # linked version resolves to a non-live state; an unresolvable linkage stays blocking
+    # (fail-closed, same as the pre-#44 behaviour).
+    def version_review_in_progress?(submission, linked_versions)
+      linkage = submission.dig("relationships", "appStoreVersionForReview", "data")
+      return false unless linkage
+      linked_version = linked_versions.find { |version| version["id"] == linkage["id"] }
+      return true unless linked_version
+      !LIVE_RELEASE_STATES.include?(linked_version.dig("attributes", "appStoreState"))
     end
 
     def get_review_submission_items(submission_id, includes)


### PR DESCRIPTION
## Problem — #44's check is defeated by real ASC data

Follow-up to #44. We hit the exact scenario #44 was written for in production today, and the merged check still blocked the release.

The blocker on our tenant was an **items-only review submission** — a standalone subscription product review, `WAITING_FOR_REVIEW` since four days prior, submitted independently of any app version. #44 should have let the app-version submission proceed past it. It didn't, because the check is:

```ruby
raise ReviewAlreadyInProgressError if in_progress.any? { |sub| sub.dig("relationships", "appStoreVersionForReview", "data") }
```

and on live data the items-only submission **carries a non-null `appStoreVersionForReview` linkage** — pointing at the app's **live `READY_FOR_SALE` version** (the previous release, long since reviewed and released), not at any version under review:

```
GET /v1/reviewSubmissions?filter[state]=WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES&filter[platform]=IOS&include=appStoreVersionForReview

data[0]:  reviewSubmissions a569ea32-… state=WAITING_FOR_REVIEW
          relationships.appStoreVersionForReview.data → appStoreVersions fb1df392-…
included: appStoreVersions fb1df392-… versionString=250.0.0 appStoreState=READY_FOR_SALE   ← the LIVE version
```

(The submission's single item is the subscription: with `include=appStoreVersion,appCustomProductPageVersion,appEvent,appStoreVersionExperimentV2` every item relationship is `null` — standalone product reviews aren't item types the public API exposes.)

So `appStoreVersionForReview` linkage presence ≠ "a version is under review". ASC links items-only submissions to the live version, and the #44 check degenerates to the old blanket behaviour precisely on the submissions it was meant to allow. This was the one case flagged as unverified in the #44 validation notes (no items-only submission was in review on our tenant at the time) — now we have the live counterexample.

## Fix

Same single API call — but also read the `appStoreVersions` resources the response already carries in its `included` payload, and block only when a linked version is in a **non-live** state:

- linkage absent → items-only → **proceed** (unchanged from #44)
- linkage resolves to a `READY_FOR_SALE` version → items-only linked to the live version → **proceed** (the fix)
- linkage resolves to any non-live version (in review / rejected / pending release) → a version really is under review → **raise**
- linkage present but unresolvable from `included` → **raise** (fail-closed, same risk asymmetry as #44: a false raise is yesterday's behaviour, a false proceed would double-submit)

## Live verification (same tenant, same method as #44)

Ran the exact request above against live ASC and the new predicate verbatim over the raw response:

| case | result |
|---|---|
| the real blocking items-only submission (linked to live `250.0.0` `READY_FOR_SALE`) | `blocking=false` ✅ unblocks the incident |
| linkage present, version missing from `included` | `blocking=true` ✅ fail-closed |
| linkage resolved to a `WAITING_FOR_REVIEW` version | `blocking=true` ✅ |
| no linkage at all | `blocking=false` ✅ |

The Spaceship plumbing (`api.get_review_submissions(..., includes:).all_pages` returning raw bodies) is unchanged from #44 and was already validated live there; `included` is populated whenever the linkage `data` is (same JSON:API include mechanism #44 already relies on).

`standardrb` clean.
